### PR TITLE
opensl: Remove android latency assertion (#558)

### DIFF
--- a/src/android/cubeb-output-latency.h
+++ b/src/android/cubeb-output-latency.h
@@ -35,7 +35,7 @@ cubeb_output_latency_load_method(int version)
 bool
 cubeb_output_latency_method_is_loaded(output_latency_function * ol)
 {
-  assert(ol && (ol->from_jni || ol->from_lib));
+  assert(ol);
   if (ol->version > ANDROID_JELLY_BEAN_MR1_4_2){
     return !!ol->from_jni;
   }

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -752,7 +752,7 @@ opensl_init(cubeb ** context, char const * context_name)
   }
 
   ctx->p_output_latency_function = cubeb_output_latency_load_method(android_version);
-  if (!ctx->p_output_latency_function) {
+  if (!cubeb_output_latency_method_is_loaded(ctx->p_output_latency_function)) {
     LOG("Warning: output latency is not available, cubeb_stream_get_position() is not supported");
   }
 


### PR DESCRIPTION
* Remove assertion that might get triggered

A method for querying latency isn't strictly required, streams
work without it. But when no method could be loaded, this assertion
would be triggered when called from opensl_configure_playback.

* Readd assertion and fix latency warning condition